### PR TITLE
Disable Prometheus packet counters

### DIFF
--- a/streaming/client.go
+++ b/streaming/client.go
@@ -152,6 +152,8 @@ type Client struct {
 	readBufferSize int
 	// packetSize defines the size of individual datagram packets (UDP)
 	packetSize int
+	// promCounter allows enabling/disabling Prometheus packet metrics.
+	promCounter bool
 }
 
 // NewClient constructs a new streaming HTTP client, without connecting the socket yet.
@@ -567,8 +569,10 @@ func (client *Client) pull(url *url.URL) error {
 
 				// report the packet
 				client.stats.PacketReceived()
-				metricPacketsReceived.With(prometheus.Labels{"stream": client.name, "url": url.String()}).Inc()
-				metricBytesReceived.With(prometheus.Labels{"stream": client.name, "url": url.String()}).Add(protocol.MpegTsPacketSize)
+				if client.promCounter {
+					metricPacketsReceived.With(prometheus.Labels{"stream": client.name, "url": url.String()}).Inc()
+					metricBytesReceived.With(prometheus.Labels{"stream": client.name, "url": url.String()}).Add(protocol.MpegTsPacketSize)
+				}
 
 				//log.Printf("Got a packet (length %d):\n%s\n", len(packet), hex.Dump(packet))
 				//log.Printf("Got a packet (length %d)\n", len(packet))

--- a/streaming/streamer.go
+++ b/streaming/streamer.go
@@ -159,6 +159,8 @@ type Streamer struct {
 	events event.Notifiable
 	// auth is an authentication verifier for client requests
 	auth auth.Authenticator
+	// promCounter allows enabling/disabling Prometheus packet metrics.
+	promCounter bool
 }
 
 // ConnectionBroker represents a policy handler for new connections.
@@ -292,8 +294,10 @@ func (streamer *Streamer) Stream(queue <-chan protocol.MpegTsPacket) error {
 
 						// report the packet
 						streamer.stats.PacketSent()
-						metricPacketsSent.With(prometheus.Labels{"stream": streamer.name}).Inc()
-						metricBytesSent.With(prometheus.Labels{"stream": streamer.name}).Add(protocol.MpegTsPacketSize)
+						if streamer.promCounter {
+							metricPacketsSent.With(prometheus.Labels{"stream": streamer.name}).Inc()
+							metricBytesSent.With(prometheus.Labels{"stream": streamer.name}).Add(protocol.MpegTsPacketSize)
+						}
 
 					default:
 						// queue is full
@@ -301,8 +305,10 @@ func (streamer *Streamer) Stream(queue <-chan protocol.MpegTsPacket) error {
 
 						// report the drop
 						streamer.stats.PacketDropped()
-						metricPacketsDropped.With(prometheus.Labels{"stream": streamer.name}).Inc()
-						metricBytesDropped.With(prometheus.Labels{"stream": streamer.name}).Add(protocol.MpegTsPacketSize)
+						if streamer.promCounter {
+							metricPacketsDropped.With(prometheus.Labels{"stream": streamer.name}).Inc()
+							metricBytesDropped.With(prometheus.Labels{"stream": streamer.name}).Add(protocol.MpegTsPacketSize)
+						}
 					}
 				}
 			} else {


### PR DESCRIPTION
`prometheus.CounterVec.Inc()` and `.Add()` aren't implemented very efficiently and can cause to performances issues when they are called frequently. Since restreamer processes each transport stream packet individually, Inc() and Add() are called for every incoming and outgoing packet. This leads to many more drops than processing only the packets would need.

The built-in performance counters don't have this issue, because they use atomic variables directly instead of locks or channels

For this reason, I'm disabling the Prometheus packet counters. Since these counters are still useful, a more efficient solution should be found.