### PR TITLE
Implement static preamble

### DIFF
--- a/cmd/restreamer/logger.go
+++ b/cmd/restreamer/logger.go
@@ -39,6 +39,7 @@ const (
 	errorMainMissingNotificationUser = "missing_notification_user"
 	errorMainMissingStreamUser       = "missing_stream_user"
 	errorMainInvalidAuthentication   = "invalid_authentication"
+	errorMainPreambleRead            = "preamble_read"
 )
 
 var logger = util.NewGlobalModuleLogger(moduleMain, nil)

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -71,6 +71,12 @@ type Resource struct {
 	// Mru (maximum receive unit) is the size of the datagram receive buffer.
 	// Only used for UDP and RTP protocols.
 	Mru uint `json:"mru"`
+	// Preamble specifies the name of a file containing a static preamble, that is sent to each client before
+	// actual data is streamed. It can be used to synchronize the decoder quickly, instead of needing to wait for
+	// the next PAT, PMT, SPS and PPS packets.
+	// Make sure that the format of the preamble content matches the stream, or you will end up with badly
+	// configured decoder!
+	Preamble string `json:preamble`
 }
 
 // UserCredentials is a set of credentials for a single user

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -76,7 +76,7 @@ type Resource struct {
 	// the next PAT, PMT, SPS and PPS packets.
 	// Make sure that the format of the preamble content matches the stream, or you will end up with badly
 	// configured decoder!
-	Preamble string `json:preamble`
+	Preamble string `json:"preamble"`
 }
 
 // UserCredentials is a set of credentials for a single user

--- a/event/queue.go
+++ b/event/queue.go
@@ -195,9 +195,10 @@ func (reporter *Queue) handleHeartbeat(when time.Time) {
 func (reporter *Queue) handleConnect(connected int) {
 	logger.Logkv(
 		"event", queueEventConnect,
-		"message", fmt.Sprintf("Number of connections changed by %d, new number of connections: %d", connected, reporter.connections),
+		"message", fmt.Sprintf("Number of connections changed by %d, current number %d, new number %d", connected, reporter.connections, reporter.connections+connected),
 		"connected", connected,
-		"connections", reporter.connections,
+		"current_connections", reporter.connections,
+		"new_connections", reporter.connections+connected,
 	)
 	// calculate the new connection count
 	var newconn int

--- a/examples/documented/restreamer.json
+++ b/examples/documented/restreamer.json
@@ -80,6 +80,10 @@
 			"": "Maximum receive unit, the packet size for datagram sockets (UDP).",
 			"": "This value is important, because individual datagrams can only be received as a whole. Excess data is discarded.",
 			"mru": 1500,
+			"": "Specify a file name to a static preamble that will be sent to each newly connected client.",
+			"": "This can help when a decoder isn't capable of initializing in the middle of a transmission,",
+			"": "but it can also make things much worse. You have been warned.",
+			"preamble": "preamble.ts",
 			"": "Access control for this resource. If not present, no authentication is necessary.",
 			"": "Otherwise, an authentication token that matches one of the users is required.",
 			"authentication": {

--- a/genpreamble.sh
+++ b/genpreamble.sh
@@ -2,8 +2,8 @@
 
 ffmpeg \
   -use_wallclock_as_timestamps 1 \
-  -t 5 -r 50 -f lavfi -i color=c=black:s=1280x720 \
-  -t 5 -f lavfi -i anullsrc=r=48000:cl=stereo \
+  -t 1 -r 50 -f lavfi -i color=c=black:s=1280x720 \
+  -t 1 -f lavfi -i anullsrc=r=48000:cl=stereo \
   -pix_fmt:v yuv420p -color_range:v tv -color_primaries:v bt709 -colorspace bt709 -color_trc bt709 -profile:v high -b:v 3500000 -c:v libx264 \
   -b:a 128000 -c:a aac \
   -f mpegts -y out.ts

--- a/genpreamble.sh
+++ b/genpreamble.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+ffmpeg \
+  -use_wallclock_as_timestamps 1 \
+  -t 5 -r 50 -f lavfi -i color=c=black:s=1280x720 \
+  -t 5 -f lavfi -i anullsrc=r=48000:cl=stereo \
+  -pix_fmt:v yuv420p -color_range:v tv -color_primaries:v bt709 -colorspace bt709 -color_trc bt709 -profile:v high -b:v 3500000 -c:v libx264 \
+  -b:a 128000 -c:a aac \
+  -f mpegts -y out.ts

--- a/streaming/connection.go
+++ b/streaming/connection.go
@@ -18,6 +18,7 @@ package streaming
 
 import (
 	"context"
+	"fmt"
 	"github.com/onitake/restreamer/protocol"
 	"net/http"
 	"time"
@@ -135,7 +136,7 @@ func (conn *Connection) Serve(preamble []byte) {
 			logger.Logkv(
 				"event", eventConnectionClosedWait,
 				"message", "Downstream connection closed (while waiting)",
-				"error", conn.context.Err(),
+				"error", fmt.Sprintf("%v", conn.context.Err()),
 			)
 			running = false
 		}

--- a/streaming/streamer.go
+++ b/streaming/streamer.go
@@ -161,6 +161,8 @@ type Streamer struct {
 	auth auth.Authenticator
 	// promCounter allows enabling/disabling Prometheus packet metrics.
 	promCounter bool
+	// preamble contains a static preamble that is sent before the actual streamed data
+	preamble []byte
 }
 
 // ConnectionBroker represents a policy handler for new connections.
@@ -203,6 +205,10 @@ func (streamer *Streamer) SetCollector(stats metrics.Collector) {
 // SetNotifier assigns an event notifier
 func (streamer *Streamer) SetNotifier(events event.Notifiable) {
 	streamer.events = events
+}
+
+func (streamer *Streamer) SetPreamble(preamble []byte) {
+	streamer.preamble = preamble
 }
 
 func (streamer *Streamer) SetInhibit(inhibit bool) {
@@ -446,7 +452,7 @@ func (streamer *Streamer) ServeHTTP(writer http.ResponseWriter, request *http.Re
 		)
 
 		start := time.Now()
-		conn.Serve()
+		conn.Serve(streamer.preamble)
 		duration := time.Since(start)
 
 		// done, remove the stale connection


### PR DESCRIPTION
This is a hackish workaround for clients that can't manage to synchronize with a stream correctly when receiving packets in the middle of a unit, without getting the PAT and PMTs as well as H.264 SPS and PPS first.

It allows sending a static TS preamble with every client connection, that should allow immediate initialization of the decoder.

**Warning:** When sending a preamble that doesn't match the data follows, this can lead to even worse results.

Potential problems:
* Demuxer and/or decoder will crash (when unexpected data is received)
* Decoding artifacts
* A/V desync (due to PTS mismatch)
* Freeze after preamble